### PR TITLE
Use html5 input type "email" on login form

### DIFF
--- a/lib/spark-browser.js
+++ b/lib/spark-browser.js
@@ -35,7 +35,7 @@ function addLoginForm() {
   form.className = 'spark-login-modal';
 
   form.appendChild(generateError());
-  form.appendChild(generateInput('email', 'text'));
+  form.appendChild(generateInput('email', 'email'));
   form.appendChild(generateInput('password', 'password'));
   form.appendChild(generateButton());
 


### PR DESCRIPTION
Use html5 "email" input type for better mobile phone keyboard layout.  Backwards-compatible.